### PR TITLE
Use proper upper bounds

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -11,11 +11,11 @@ description: Please see the README
 
 dependencies:
 - name: base
-  version: ">= 4.12.0.0 && < 5"
+  version: ">= 4.12.0.0 && < 4.14"
 - name: bytestring
-  version: ">= 0.10.8.2 && < 1"
+  version: ">= 0.10.8.2 && < 0.11"
 - name: text
-  version: ">= 1.2.3.1 && < 2"
+  version: ">= 1.2.3.1 && < 1.3"
 
 ghc-options:
 - -Wall


### PR DESCRIPTION
Hackage uses PVP instead of SemVer, see also https://pvp.haskell.org/faq/#how-does-the-pvp-relate-to-semantic-versioning-semver